### PR TITLE
Splash screen

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,9 @@
   <component name="DependencyValidationManager">
     <option name="SKIP_IMPORT_STATEMENTS" value="false" />
   </component>
+  <component name="HudsonMonitorComponent">
+    <option name="timeOutTextField" value="30" />
+  </component>
   <component name="IdProvider" IDEtalkID="D658F470B7CBA8ADBA4F9EC58FCEC741" />
   <component name="JavadocGenerationManager">
     <option name="OUTPUT_DIRECTORY" />
@@ -30,5 +33,6 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="WebServicesPlugin" addRequiredLibraries="true" />
 </project>
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -3,6 +3,6 @@
 project.organization=com.github.retronym
 project.name=sbt-onejar
 sbt.version=0.7.4
-project.version=0.2
+project.version=0.3.splash-screen-SNAPSHOT
 build.scala.versions=2.7.7
 project.initialize=false


### PR DESCRIPTION
lazy val splashScreenImage: Option[Path] = None

can be used to specify the Path to a image file. This file will be added to the onejar jar file and the filename will be added to the onejar MANIFEST for key SplashScreen-Image.

I extended onejarPackageOptions. I have used a Listbuffer. There must be a nicer way to do this.

Please review.
